### PR TITLE
Change to f-strings

### DIFF
--- a/notice_communication/__main__.py
+++ b/notice_communication/__main__.py
@@ -29,7 +29,8 @@ def main():
 
     if os.getenv('TWITTER_BEARER_TOKEN'):
         twitter = get_twitter_client()
-        tweet = f"{(f'{summary[:220] if len(summary) > 220 else summary)}...'} {url} #BugAlertNotice"
+        tweet_summary = summary[:220] if len(summary) > 220 else summary
+        tweet = f"{f'{tweet_summary}...'} {url} #BugAlertNotice"
         twitter.create_tweet(text=tweet)
 
     if os.getenv('TEXT_EM_ALL_ID'):

--- a/notice_communication/__main__.py
+++ b/notice_communication/__main__.py
@@ -11,7 +11,7 @@ from requests_oauthlib import OAuth1Session
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-os.environ['PATH'] = "%s:%s" % (os.environ['PATH'], SCRIPT_PATH)
+os.environ['PATH'] = f"{os.environ['PATH']}:{SCRIPT_PATH}"
 
 TEXTEMALL_BASE_DOMAIN = "staging-rest.call-em-all.com"
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -26,8 +26,8 @@ def main():
 
     if os.getenv('TWITTER_BEARER_TOKEN'):
         twitter = get_twitter_client()
-        url = "https://bugalert.org/%s" % filename.replace('md', 'html')
-        tweet = "%s %s #BugAlertNotice" % (("%s..." % summary[:220] if len(summary) > 220 else summary), url)
+        url = f"https://bugalert.org/{filename.replace('md', 'html')}"
+        tweet = f"{(f'{summary[:220] if len(summary) > 220 else summary)}...'} {url} #BugAlertNotice"
         twitter.create_tweet(text=tweet)
 
     if os.getenv('TEXT_EM_ALL_ID'):
@@ -67,7 +67,7 @@ def send_telephony(summary, filename)
 def generate_tts(summary):
     # Instantiates a client
     client = texttospeech.TextToSpeechClient()
-    synthesis_input = texttospeech.SynthesisInput(text="%s The notice will be played once more. %s" % (summary, summary))
+    synthesis_input = texttospeech.SynthesisInput(text=f"{summary} The notice will be played once more. {summary}")
 
     # Build the voice request, select the language code ("en-US")
     voice = texttospeech.VoiceSelectionParams(
@@ -103,7 +103,7 @@ def get_summary(filename):
     return summary
 
 def upload_audio(filename, sess):
-    url = "https://%s/v1/audio/%s" % (TEXTEMALL_BASE_DOMAIN, filename)
+    url = f"https://{TEXTEMALL_BASE_DOMAIN}/v1/audio/{filename}"
     payload={}
     files=[
       ('File',(filename,open(filename,'rb'),'audio/mpeg'))
@@ -117,7 +117,7 @@ def upload_audio(filename, sess):
     return response.json()['AudioID']
 
 def create_broadcast(audioid, filename, sess):
-    url = "https://%s/v1/broadcasts" % TEXTEMALL_BASE_DOMAIN
+    url = f"https://{TEXTEMALL_BASE_DOMAIN}/v1/broadcasts"
     payload={'BroadcastName': filename, 'BroadcastType': 'Announcement', 'StartDate': '', 'CallerID': '5076688567', 'Audio': {'AudioID': audioid}, 'Lists': [{'ListID': '2'}]}
     response = sess.post(url, json=payload)
     return response.json()

--- a/notice_communication/__main__.py
+++ b/notice_communication/__main__.py
@@ -107,9 +107,8 @@ def generate_tts(summary):
 
 
 def get_summary_and_category(filename):
-    f = open(filename, 'r')
-    notice = f.read()
-    f.close()
+    with open(filename, 'r') as f:
+        notice = f.read()
 
     pattern = "Summary: (.*)"
     groups = re.search(pattern, notice)

--- a/plugins/manifest.py
+++ b/plugins/manifest.py
@@ -23,7 +23,7 @@ class ManifestGenerator(Generator):
             manifest.write(json.dumps(data, indent=4))
 
     def _create_url(self, relative_url):
-        return '%s/%s' % (self.settings.get('SITEURL', ''), relative_url)
+        return f'{self.settings.get('SITEURL', '')}/{relative_url}'
 
     def _convert_wrapper(self, obj):
 

--- a/subscription_management/lambda_function.py
+++ b/subscription_management/lambda_function.py
@@ -113,8 +113,8 @@ def lambda_handler(event, context):
         # Fire off email to confirm the user is allowed to make subscription changes.
         locally_computed_hmac = hmac.new(hmacsecret, codecs.encode(email), hashlib.sha256).digest()
         signature = base64.urlsafe_b64encode(locally_computed_hmac).decode('utf8').rstrip("=")
-        msg_body = f"Please visit the following URL to verify your email address: "
-                   f"https://bugalert.org/content/pages/my-subscriptions.html"
+        msg_body = f"Please visit the following URL to verify your email address: " \
+                   f"https://bugalert.org/content/pages/my-subscriptions.html" \
                    f"?signature={signature}&email={email}"
         ses.send_email(
             Destination={

--- a/subscription_management/lambda_function.py
+++ b/subscription_management/lambda_function.py
@@ -108,7 +108,8 @@ def lambda_handler(event, context):
         # A future improvement could be made to authenticate this, but for the moment,
         # I don't forsee anyone DoS-ing this endpoint causing any harm.
         sms_file_id, phone_file_id = upload_telephony_contact_list(body.get('category'))
-        return respond_success(f"{{\"status\": \"success\", \"sms_file_id\": \"{sms_file_id}\", \"phone_file_id\": \"{phone_file_id}\"}}", origin)
+        json_content = f"{{\"status\": \"success\", \"sms_file_id\": \"{sms_file_id}\", \"phone_file_id\": \"{phone_file_id}\"}}"
+        return respond_success(json_content, origin)
     elif method == 'POST' and path == 'verify':
         # Fire off email to confirm the user is allowed to make subscription changes.
         locally_computed_hmac = hmac.new(hmacsecret, codecs.encode(email), hashlib.sha256).digest()

--- a/subscription_management/lambda_function.py
+++ b/subscription_management/lambda_function.py
@@ -254,27 +254,23 @@ def upload_telephony_contact_list(category):
         data.extend(response['Items'])
 
     # TODO tempfile lib!
-    sms_file = open('/tmp/sms.csv', 'w')
-    sms_file.write("First Name,Last Name,Notes,Phone Number")
-    phone_file = open('/tmp/phone.csv', 'w')
-    phone_file.write("First Name,Last Name,Notes,Phone Number")
-    # https://newbedev.com/using-boto3-in-python-to-acquire-results-from-dynamodb-and-parse-into-a-usable-variable-or-dictionary
-    for i in data:
-        contact = ast.literal_eval((json.dumps(i)))
-        if 's' in contact[category] and contact.get('phone_country_code') and contact.get('phone_number') and contact.get('phone_country_code') == 1:
-            sms_file.write(f"Bugs,Allert,bugs.allert@example.com,1{contact.get('phone_number')}\n")
-        if 'p' in contact[category] and contact.get('phone_country_code') and contact.get('phone_number') and contact.get('phone_country_code') == 1:
-            phone_file.write(f"Bugs,Allert,bugs.allert@example.com,1{contact.get('phone_number')}\n")
+    with open('/tmp/sms.csv', 'w') as sms_file, open('/tmp/phone.csv', 'w') as phone_file:
+        sms_file.write("First Name,Last Name,Notes,Phone Number")
+        phone_file.write("First Name,Last Name,Notes,Phone Number")
+        # https://newbedev.com/using-boto3-in-python-to-acquire-results-from-dynamodb-and-parse-into-a-usable-variable-or-dictionary
+        for i in data:
+            contact = ast.literal_eval((json.dumps(i)))
+            if 's' in contact[category] and contact.get('phone_country_code') and contact.get('phone_number') and contact.get('phone_country_code') == 1:
+                sms_file.write(f"Bugs,Allert,bugs.allert@example.com,1{contact.get('phone_number')}\n")
+            if 'p' in contact[category] and contact.get('phone_country_code') and contact.get('phone_number') and contact.get('phone_country_code') == 1:
+                phone_file.write(f"Bugs,Allert,bugs.allert@example.com,1{contact.get('phone_number')}\n")
 
-    sms_file.close()
-    phone_file.close()
-
-    # Now put them on telephony services
-    sms_file_id = upload_contacts('/tmp/sms.csv')
-    phone_file_id = upload_contacts('/tmp/phone.csv')
-    print(f"sms_file_id: {sms_file_id}")
-    print(f"phone_file_id: {phone_file_id}")
-    return sms_file_id, phone_file_id
+        # Now put them on telephony services
+        sms_file_id = upload_contacts('/tmp/sms.csv')
+        phone_file_id = upload_contacts('/tmp/phone.csv')
+        print(f"sms_file_id: {sms_file_id}")
+        print(f"phone_file_id: {phone_file_id}")
+        return sms_file_id, phone_file_id
     
 
 def upload_contacts(filepath):

--- a/subscription_management/lambda_function.py
+++ b/subscription_management/lambda_function.py
@@ -108,14 +108,14 @@ def lambda_handler(event, context):
         # A future improvement could be made to authenticate this, but for the moment,
         # I don't forsee anyone DoS-ing this endpoint causing any harm.
         sms_file_id, phone_file_id = upload_telephony_contact_list(body.get('category'))
-        return respond_success("{\"status\": \"success\", \"sms_file_id\": \"%s\", \"phone_file_id\": \"%s\"}" % (sms_file_id, phone_file_id), origin)
+        return respond_success(f"{{\"status\": \"success\", \"sms_file_id\": \"{sms_file_id}\", \"phone_file_id\": \"{phone_file_id}\"}}", origin)
     elif method == 'POST' and path == 'verify':
         # Fire off email to confirm the user is allowed to make subscription changes.
         locally_computed_hmac = hmac.new(hmacsecret, codecs.encode(email), hashlib.sha256).digest()
         signature = base64.urlsafe_b64encode(locally_computed_hmac).decode('utf8').rstrip("=")
-        msg_body = "Please visit the following URL to verify your email address: " \
-                   "https://bugalert.org/content/pages/my-subscriptions.html" \
-                   "?signature={}&email={}".format(signature, email)
+        msg_body = f"Please visit the following URL to verify your email address: "
+                   f"https://bugalert.org/content/pages/my-subscriptions.html"
+                   f"?signature={signature}&email={email}"
         ses.send_email(
             Destination={
                 'ToAddresses': [
@@ -262,9 +262,9 @@ def upload_telephony_contact_list(category):
     for i in data:
         contact = ast.literal_eval((json.dumps(i)))
         if 's' in contact[category] and contact.get('phone_country_code') and contact.get('phone_number') and contact.get('phone_country_code') == 1:
-            sms_file.write("Bugs,Allert,bugs.allert@example.com,1%s\n" % contact.get('phone_number'))
+            sms_file.write(f"Bugs,Allert,bugs.allert@example.com,1{contact.get('phone_number')}\n")
         if 'p' in contact[category] and contact.get('phone_country_code') and contact.get('phone_number') and contact.get('phone_country_code') == 1:
-            phone_file.write("Bugs,Allert,bugs.allert@example.com,1%s\n" % contact.get('phone_number'))
+            phone_file.write(f"Bugs,Allert,bugs.allert@example.com,1{contact.get('phone_number')}\n")
 
     sms_file.close()
     phone_file.close()
@@ -272,8 +272,8 @@ def upload_telephony_contact_list(category):
     # Now put them on telephony services
     sms_file_id = upload_contacts('/tmp/sms.csv')
     phone_file_id = upload_contacts('/tmp/phone.csv')
-    print("sms_file_id: %s" % sms_file_id)
-    print("phone_file_id: %s" % sms_file_id)
+    print(f"sms_file_id: {sms_file_id}")
+    print(f"phone_file_id: {phone_file_id}")
     return sms_file_id, phone_file_id
     
 
@@ -281,8 +281,8 @@ def upload_contacts(filepath):
     with open(filepath, 'r') as f:
         payload = f.read()
 
-    print("Sending payload: %s" % payload)
-    url = "https://%s/v1/fileuploads" % TEXTEMALL_BASE_DOMAIN
+    print(f"Sending payload: {payload}"
+    url = f"https://{TEXTEMALL_BASE_DOMAIN}/v1/fileuploads"
     headers = {
           'Accept': 'application/json',
           'Content-Type': 'text/csv',


### PR DESCRIPTION
This changes all string replacements to be done via the more-contemporary [f-string](https://realpython.com/python-f-strings/) way.

### Things to double check
- [ ] each f-string starts with an `f`
- [ ] nested f-strings function as expected (i think there was only one)
- [ ] the multi-line f-string doing the header build [works as expected](https://realpython.com/python-f-strings/#multiline-f-strings)

I'll call out in the PR diff places to triple check.

### For Site Improvements

- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by the Bug Alert team if needed.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have run Pelican locally to ensure my changes have not disrupted the look, feel, or functionality of the site.
- [x] I have checked my code and corrected any misspellings.
- [x] I have added a pull request description which details the nature of this change.
