### PR TITLE
Don't validate email

### DIFF
--- a/subscription_management/lambda_function.py
+++ b/subscription_management/lambda_function.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from requests_oauthlib import OAuth1Session
 from sendgrid import SendGridAPIClient
 from boto3.dynamodb.conditions import Key, Attr
-from email_validator import validate_email, EmailNotValidError
+#from validate_email import validate_email  # there is some issue with importing this, disabling for now
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -102,14 +102,11 @@ def lambda_handler(event, context):
     if not email:
         return respond_error("No email field value", origin)
 
-    try:
-      # Validate email
-      valid = validate_email(email)
-      # Update with the normalized form.
-      email = valid.email
-    except EmailNotValidError as e:
-      # email is not valid, exception message is human-readable
-      return respond_error("Email field is not valid: '{}'".format(str(e)), origin)
+    # Validate email
+    #valid = validate_email(email)
+    #if not valid:
+    #  # email is not valid, exception message is human-readable
+    #  return respond_error("Email field is not valid: '{}'".format(str(e)), origin)
 
     if method == 'POST' and path == 'listup':
         # RPC to dump the contact list from dynamo into telephony provider.

--- a/subscription_management/requirements.txt
+++ b/subscription_management/requirements.txt
@@ -1,6 +1,6 @@
 requests-oauthlib==1.3.0
 boto3==1.20.26
-email_validator==1.1.3
+#py3-validate-email==1.0.5
 simplejson==3.17.6
 sendgrid==6.9.3
 requests==2.26.0

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -53,8 +53,7 @@
       location.search.substr(1).split("&").forEach(function (pair) {
           if (pair === "") return;
           var parts = pair.split("=");
-          location.queryString[parts[0]] = parts[1] &&
-              decodeURIComponent(parts[1].replace(/\+/g, " "));
+          location.queryString[parts[0]] = parts[1];
       });
 
       // Numeric only control handler


### PR DESCRIPTION
The email validator I choose originally is super, super old, apparently (hasn't been updated since 2015). I wanted to move up to a newer one to fix #7, but I've gotten an import error on the lambda side I don't get locally with the new library. Simply removing validation for now, it's low value anyway.