### PR TITLE
Improvement: front matter convention, add separators

### DIFF
--- a/content/notices/2021-12-09-log4j.md
+++ b/content/notices/2021-12-09-log4j.md
@@ -4,5 +4,6 @@ Category: Software Frameworks, Libraries, and Components
 Tags: Java, Log4j, Critical Severity
 Slug: log4j
 Summary: A remote code execution vulnerability has been found in the popular Java logging library Log4j. This issue is easily exploited in common configurations, and has been assigned a bug alert severity of 'critical'.
+---
 
 On Tuesday, December 9th, 2021, a security researcher posted a screenshot and proof-of-concept code for executing an RCE against the latest available build of the popular Java logging library, Log4j. For up-to-date information, please visit [https://www.lunasec.io/docs/blog/log4j-zero-day/](https://www.lunasec.io/docs/blog/log4j-zero-day/).

--- a/content/notices/2021-12-09-log4j.md
+++ b/content/notices/2021-12-09-log4j.md
@@ -1,3 +1,4 @@
+---
 Title: RCE in Log4j
 Date: 2021-12-09 23:00
 Category: Software Frameworks, Libraries, and Components

--- a/content/notices/2022-01-04-bugalert.md
+++ b/content/notices/2022-01-04-bugalert.md
@@ -1,8 +1,10 @@
+---
 Title: Bug Alert is Live
 Date: 2022-01-04 14:00
 Category: Test
 Tags: 
 Slug: bugalert
 Summary: Hello, world! Bug Alert is now live. Read the announcement post at https://mattslifebytes.com/2022/01/04/bugalert-org/ to learn more.
+---
 
 I'm happy announce that Bug Alert is now generally-available! Read the announcement post at [https://mattslifebytes.com/2022/01/04/bugalert-org/](https://mattslifebytes.com/2022/01/04/bugalert-org/) for background and further information.

--- a/content/notices/202X-MM-DD-slug.md.template
+++ b/content/notices/202X-MM-DD-slug.md.template
@@ -1,9 +1,10 @@
+---
 Title: <VULN TYPE> in <NAME OF IMPACTED PRODUCT OR COMPONENT>
 Date: 202X-MM-DD HH:MM <DATE IN AMERICA/NEW_YORK>
 Category: <'Software Frameworks, Libraries, and Components', 'Operating Systems', 'System Applications', OR 'End-User Applications'. SEE README FOR DETAILS.>
 Tags: <COMMA-SEPARATED LIST OF RELEVANT COMPONENTS, E.G. 'Java', 'Jackson Databind', ETC. INCLUDE SEVERITY ('High'/'Very High'/'Critical') AS A TAG.>
 Slug: <NAME OF IMPACTED PRODUCT OR COMPONENT>
 Summary: A <VULN TYPE> vulnerability has been found in <NAME OF IMPACTED PRODUCT OR COMPONENT>. This issue <'is easily exploited in common configurations', 'can be exploited in certain specific configurations', OR 'is not easily exploited, but has high impact'>, and has been assigned a bug alert severity of <'critical', 'very high', OR 'high'>.
-
+---
 
 On <VERBOSE DATE IN AMERICA/NEW_YORK, E.G. 'Tuesday, December 9th, 2021'>, [...]

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -1,4 +1,6 @@
+---
 title: About
+---
 
 #### Bug Alert is a service for alerting security and IT professionals of high-impact and 0day vulnerabilities.
 Hi, I'm Matthew Sullivan, a security practitioner, and the founder of Bug Alert.

--- a/content/pages/financial-support.md
+++ b/content/pages/financial-support.md
@@ -1,4 +1,6 @@
+---
 title: Financial Support
+---
 
 As Bug Alert grows, it will be a moderately costly service to run. If a subscriber receives a notice using all three methods (email, SMS, phone), that notice will cost approximately $0.20 USD to send. Multiply that by, say, 10,000 subscribers, and we find that this notice suddenly costs $2,000 USD to send.
 

--- a/content/pages/privacy.md
+++ b/content/pages/privacy.md
@@ -1,4 +1,6 @@
+---
 title: Privacy Policy
+---
 
 ### Overview
 Bug Alert will never sell or make available your data. This project is not intended to make me (Matthew Sullivan - the founder and maintainer), money. In fact, I'm quite sure it will do the opposite with great efficiency.

--- a/content/pages/webhook-format.md
+++ b/content/pages/webhook-format.md
@@ -1,4 +1,6 @@
+---
 title: Webhook Format
+---
 
 Webhook calls will POST a JSON body with the following format and content:
 ```


### PR DESCRIPTION
# description

Having a front matter with `---` separator before and after is more conventional and supported by many tools including GitHub. It is supported by Pelican.

# Contributor Checklist

- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by the Bug Alert team if needed.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have run Pelican locally to ensure my changes have not disrupted the look, feel, or functionality of the site.
- [x] I have checked my code and corrected any misspellings.
- [x] I have added a pull request description which details the nature of this change.

Leave the following intact, which notifies our volunteer team: @BugAlertDotOrg/volunteer-team 
