### PR TITLE
Announce Telegram, Slack, and give general updates

### DIFF
--- a/content/notices/2022-01-04-bugalert.md
+++ b/content/notices/2022-01-04-bugalert.md
@@ -1,7 +1,7 @@
 ---
 Title: Bug Alert is Live
 Date: 2022-01-04 14:00
-Category: Test
+Category: Bug Alert News
 Tags: 
 Slug: bugalert
 Summary: Hello, world! Bug Alert is now live. Read the announcement post at https://mattslifebytes.com/2022/01/04/bugalert-org/ to learn more.

--- a/content/notices/2022-01-11-post-launch.md
+++ b/content/notices/2022-01-11-post-launch.md
@@ -1,0 +1,42 @@
+---
+Title: Post-Launch Updates: Telegram Support, Community Slack, and Celebrating Success
+Date: 2022-01-11 23:00
+Category: Bug Alert News
+Tags: Telegram, Slack
+Slug: post-launch
+Summary: The Bug Alert team is celebrating a successful launch with more features (Telegram support!), a community Slack, and more.
+---
+
+
+<p align="center"> 
+	<img width="50%" src="https://i.imgur.com/TbDWmWr.png"> 
+</p>
+
+The Bug Alert team is happy to announce Telegram support! [Join our Telegram channel](https://t.me/s/BugAlert) to receive vulnerability notices in real-time.
+
+This functionality was contributed by a member of our volunteer team, [Ethan Schorer](https://github.com/BugAlertDotOrg/bugalert/pull/26). Thanks Ethan!
+
+<hr>
+
+<p align="center"> 
+	<img width="40%" src="https://i.imgur.com/EKU8YJB.png"> 
+</p>
+Stay up to date on the latest Bug Alert news or come chat vulnerabilities in our public Slack workspace. This is also where the volunteer team discusses features and updates, and we'd be happy to get your input as well!
+
+[Click here to create an account.](https://join.slack.com/t/bug-alert/shared_invite/zt-1199f3i50-Fz2kn0D3Oa1z3fQBHTdzAw)
+
+<hr>
+
+<p align="center"> 
+	<font size="100%"> &#x1f389; Post-Launch Celebration</font>
+</p>
+
+Over 1,000 subscribers have registered with Bug Alert, which is far in excess of what I could have imagined just a week ago. I am honored you agree that Bug Alert is a potential solution to a very real problem, and as a community, we'll work to improve security across the world.
+
+If you have suggestions for Bug Alert, or wish functionality existed which doesn't today, please [file an issue on GitHub](https://github.com/BugAlertDotOrg/bugalert/issues) and let us know! If you know Python, we'd also love to have you contribute to our codebase to make those ideas a reality.
+
+Thanks again for making Bug Alert an early success. We look forward to what the future has in store.
+
+<hr>
+
+P.S. If you haven't already, [follow us on Twitter](https://twitter.com/BugAlertDotOrg). While notices are also posted to Twitter, we'll also use the platform for disseminating less pressing, informational content, such as minor feature enhancements or bugfixes. Notices will always be tagged with `#BugAlertNotice`, which you can use for filtering alerts if you are utilizing tools like IFTTT to monitor the feed and only want to see the emergency stuff. Hope to see you there!


### PR DESCRIPTION
A small post announcing the new Telegram support as well as the Slack workspace. Added a new category and changed the notification code so that only Twitter will ever consume the news feed.

### For Site Improvements

- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by the Bug Alert team if needed.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have run Pelican locally to ensure my changes have not disrupted the look, feel, or functionality of the site.
- [x] I have checked my code and corrected any misspellings.
- [x] I have added a pull request description which details the nature of this change.

@mattlorimor 