### PR TITLE
Improvement: Allow SendGrid more time to process contact lists

### DIFF
--- a/notice_communication/__main__.py
+++ b/notice_communication/__main__.py
@@ -207,7 +207,7 @@ def create_email_broadcast(summary, category, title, url, slug, filename, email_
     sg = SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))
 
     # Give SendGrid a bit to process the contact list additions
-    send_date = datetime.datetime.utcnow() + datetime.timedelta(minutes=3)
+    send_date = datetime.datetime.utcnow() + datetime.timedelta(minutes=6)
     send_date = send_date.replace(microsecond=0).isoformat() + "Z"
     data = {
         "name": f"{filename}-{send_date}",


### PR DESCRIPTION
https://github.com/BugAlertDotOrg/bugalert/pull/53 failed to send an email.

It appears SendGrid needed more time to parse the contact list before firing off the send email event. Doubling the amount of time in hopes it gives SendGrid plenty of headroom. 

Fixes https://github.com/BugAlertDotOrg/bugalert/issues/54